### PR TITLE
Updated market to markets in CriteriaSearch

### DIFF
--- a/docs/apis/for-buyers/hotel-x-pull-buyers-api/booking-flow/search.mdx
+++ b/docs/apis/for-buyers/hotel-x-pull-buyers-api/booking-flow/search.mdx
@@ -69,7 +69,7 @@ To specify your search criteria you need to use the input `HotelCriteriaSearchIn
             "2"
 		],
 		"currency": "EUR",
-		"market": "ES",
+		"markets": ["ES"],
 		"language": "es",
 		"nationality": "ES"
 	}


### PR DESCRIPTION
Market is deprecated, the correct use is markets []string